### PR TITLE
call highlightAuto() for undefined language

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -17,7 +17,7 @@ module.exports = function showdownHighlight () {
                         match = decodeHtml(match);
                         let lang = (left.match(/class=\"([^ \"]+)/) || [])[1];
                         left = left.slice(0, 18) + 'hljs ' + left.slice(18);
-                        if (lang) {
+                        if (lang && hljs.getLanguage(lang)) {
                             return left + hljs.highlight(lang, match).value + right;
                         } else {
                             return left + hljs.highlightAuto(match).value + right;


### PR DESCRIPTION
call highlightAuto() when it was undefined language to avoid an assertion "unknown language"