### PR TITLE
Allow blocks without language

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,7 @@
 const decodeHtml = require("html-encoder-decoder").decode
     , showdown = require("showdown")
     , hljs = require("highlight.js")
+    , classAttr = 'class="'
     ;
 
 module.exports = function showdownHighlight () {
@@ -16,7 +17,14 @@ module.exports = function showdownHighlight () {
                   , replacement = (wholeMatch, match, left, right) => {
                         match = decodeHtml(match);
                         let lang = (left.match(/class=\"([^ \"]+)/) || [])[1];
-                        left = left.slice(0, 18) + 'hljs ' + left.slice(18);
+
+                        if (left.includes(classAttr)) {
+                          let attrIndex = left.indexOf(classAttr) + classAttr.length;
+                          left = left.slice(0, attrIndex) + 'hljs ' + left.slice(attrIndex);
+                        } else {
+                          left = left.slice(0, -1) + ' class="hljs">';
+                        }
+                        
                         if (lang && hljs.getLanguage(lang)) {
                             return left + hljs.highlight(lang, match).value + right;
                         } else {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "description": "This package uses [`highlight.js`](https://highlightjs.org) to highlight code blocks in [Showdown](https://github.com/showdownjs/showdown) output. :rocket:"
   },
   "contributors": [
-    "Cristiano Ribeiro <expedit@gmail.com> (https://github.com/expedit85)"
+    "Cristiano Ribeiro <expedit@gmail.com> (https://github.com/expedit85)",
+    "obedm503 (https://obedm503.github.io)"
   ]
 }

--- a/test/index.js
+++ b/test/index.js
@@ -6,12 +6,12 @@ const tester = require("tester")
     ;
 
 tester.describe("showdown-highlight", t => {
-    t.should("A Showdown extension for highlight the code blocks.", () => {
-        // After requiring the module, use it as extension
-        let converter = new showdown.Converter({
-            extensions: [showdownHighlight]
-        });
+    // After requiring the module, use it as extension
+    let converter = new showdown.Converter({
+        extensions: [showdownHighlight]
+    });
 
+    t.should("A Showdown extension for highlight the code blocks.", () => {
         // Now you can Highlight code blocks
         let html = converter.makeHtml(`
 \`\`\`js
@@ -22,7 +22,21 @@ sayHello("Hello World", "Johnny");
 \`\`\`
         `);
 
-        t.expect(html.includes('hljs js language-js')).toEqual(true);
+        t.expect(html.includes('class="hljs js language-js"')).toEqual(true);
         t.expect(html.includes("hljs-string")).toEqual(true);
+    });
+
+    t.should("work without code block language", () => {
+        // Now you can Highlight code blocks
+        let html = converter.makeHtml(`
+\`\`\`
+function sayHello (msg, who) {
+  return \`\${who} says: msg\`;
+}
+sayHello("Hello World", "Johnny");
+\`\`\`
+        `);
+
+        t.expect(html.includes('class="hljs"')).toEqual(true);
     });
 });


### PR DESCRIPTION
Currently, if a code block does not define a language, the extension adds `hljs ` at the beginning of the code block (after the `<pre><code>`. This pr addresses the issue by first checking whether the `<code>` element has a `class` attribute then adding the `hljs` class correctly. The code currently assumes that all `<code>` elements have a single attribute (uses a fixed index of 18) and that attribute is `class`.

I tried to follow the style guide as much as possible. If something is not correctly formatted, feel free to let me know.

related to #11 