### PR TITLE
Add TypeScript types

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,0 +1,4 @@
+import type { ShowdownExtension } from 'showdown';
+
+declare function showdownHighlight(): ShowdownExtension[];
+export = showdownHighlight;

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "blocks"
   ],
   "license": "MIT",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "main": "lib/index.js",
   "author": "Bloggify <support@bloggify.org> (https://bloggify.org)",
   "files": [

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   },
   "contributors": [
     "Cristiano Ribeiro <expedit@gmail.com> (https://github.com/expedit85)",
-    "obedm503 (https://obedm503.github.io)"
+    "obedm503 (https://obedm503.github.io)",
+    "Ariel Shaqed (Scolnicov) (https://github.com/arielshaqed)"
   ]
 }


### PR DESCRIPTION
Tested by seeing I can
```ts
import showdown from 'showdown';
import highlight from 'showdown-highlight';

// ...
const converter = new showdown.Converter({
    extensions: [highlight],
}
```
in TypeScript (with `--noImplicitAny`).

Thanks!