### PR TITLE
Pre class

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,4 +1,6 @@
-import type { ShowdownExtension } from 'showdown';
+import type { ShowdownExtension } from "showdown";
 
-declare function showdownHighlight(): ShowdownExtension[];
+declare function showdownHighlight({
+  pre: Boolean = false,
+}): ShowdownExtension[];
 export = showdownHighlight;

--- a/lib/index.js
+++ b/lib/index.js
@@ -26,7 +26,7 @@ module.exports = function showdownHighlight({ pre = false }) {
             }
 
             if (pre && lang) {
-              left = left.replace('<pre>', `<pre class="language-${lang}">`);
+              left = left.replace('<pre>', `<pre class="${lang} language-${lang}">`);
             }
 
             if (lang && hljs.getLanguage(lang)) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,40 +1,44 @@
 "use strict";
 
 const decodeHtml = require("html-encoder-decoder").decode
-    , showdown = require("showdown")
-    , hljs = require("highlight.js")
-    , classAttr = 'class="'
-    ;
+  , showdown = require("showdown")
+  , hljs = require("highlight.js")
+  , classAttr = 'class="'
+  ;
 
-module.exports = function showdownHighlight () {
-    return [
-        {
-            type: "output"
-          , filter (text, converter, options) {
-                let left  = "<pre><code\\b[^>]*>"
-                  , right = "</code></pre>"
-                  , flags = "g"
-                  , replacement = (wholeMatch, match, left, right) => {
-                        match = decodeHtml(match);
-                        let lang = (left.match(/class=\"([^ \"]+)/) || [])[1];
+module.exports = function showdownHighlight({ pre = false }) {
+  return [
+    {
+      type: "output"
+      , filter(text, converter, options) {
+        let left = "<pre><code\\b[^>]*>"
+          , right = "</code></pre>"
+          , flags = "g"
+          , replacement = (wholeMatch, match, left, right) => {
+            match = decodeHtml(match);
+            let lang = (left.match(/class=\"([^ \"]+)/) || [])[1];
 
-                        if (left.includes(classAttr)) {
-                          let attrIndex = left.indexOf(classAttr) + classAttr.length;
-                          left = left.slice(0, attrIndex) + 'hljs ' + left.slice(attrIndex);
-                        } else {
-                          left = left.slice(0, -1) + ' class="hljs">';
-                        }
-                        
-                        if (lang && hljs.getLanguage(lang)) {
-                            return left + hljs.highlight(lang, match).value + right;
-                        } else {
-                            return left + hljs.highlightAuto(match).value + right;
-                        }
-                    }
-                  ;
-
-                return showdown.helper.replaceRecursiveRegExp(text, replacement, left, right, flags);
+            if (left.includes(classAttr)) {
+              let attrIndex = left.indexOf(classAttr) + classAttr.length;
+              left = left.slice(0, attrIndex) + 'hljs ' + left.slice(attrIndex);
+            } else {
+              left = left.slice(0, -1) + ' class="hljs">';
             }
-        }
-    ];
+
+            if (pre && lang) {
+              left = left.replace('<pre>', `<pre class="language-${lang}">`);
+            }
+
+            if (lang && hljs.getLanguage(lang)) {
+              return left + hljs.highlight(lang, match).value + right;
+            } else {
+              return left + hljs.highlightAuto(match).value + right;
+            }
+          }
+          ;
+
+        return showdown.helper.replaceRecursiveRegExp(text, replacement, left, right, flags);
+      }
+    }
+  ];
 };

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   "contributors": [
     "Cristiano Ribeiro <expedit@gmail.com> (https://github.com/expedit85)",
     "obedm503 (https://obedm503.github.io)",
-    "Ariel Shaqed (Scolnicov) (https://github.com/arielshaqed)"
+    "Ariel Shaqed (Scolnicov) (https://github.com/arielshaqed)",
+    "Bruno de Araújo Alves (devbaraus) (https://github.com/devbaraus)"
   ]
 }


### PR DESCRIPTION
Context #22 

Added option to insert language class to pre tag.

# Example

```js
const showdown = require('showdown')
    , showdownHighlight = require("showdown-highlight")
    ;
 
// After requiring the module, use it as extension
let converter = new showdown.Converter({
    // That's it
    extensions: [showdownHighlight({ **pre**: true )]
});
 
// Now you can Highlight code blocks
let html = converter.makeHtml(`
## Highlighting Code with Showdown
 
Below we have a piece of JavaScript code:
 
\`\`\`js
function sayHello (msg, who) {
    return \`\${who} says: msg\`;
}
sayHello("Hello World", "Johnny");
\`\`\`
`);
 
console.log(html);
// <h2 id="highlightingcodewithshowdown">Highlighting Code with Showdown</h2>
//
// <p>Below we have a piece of JavaScript code:</p>
//
// <pre class="js language-js"><code class="js language-js"><span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">sayHello</span> (<span class="hljs-params">msg, who</span>) </span>{
//     <span class="hljs-keyword">return</span> <span class="hljs-string">`<span class="hljs-subst">${who}</span> says: msg`</span>;
// }
// sayHello(<span class="hljs-string">"Hello World"</span>, <span class="hljs-string">"Johnny"</span>);
// </code></pre>
```