### PR TITLE
Fix bug with destructuring undefined

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -29,7 +29,7 @@ const decodeHtml = require("html-encoder-decoder").decode
  * @name showdownHighlight
  * @function
  */
-module.exports = function showdownHighlight({ pre = false }) {
+module.exports = function showdownHighlight({ pre = false } = {}) {
   return [
     {
       type: "output"


### PR DESCRIPTION
Hey, the current version (v.2.1.7) seems to be broken as even the tests fail.
The problem is that javascript can't destructure the function parameter if it's `undefined`.
https://github.com/Bloggify/showdown-highlight/blob/5f882736c9d75a0937d78c39e64c118974990c1a/lib/index.js#L32

An easy fix is to add a default value to the function parameter `function showdownHighlight({ pre = false } = {})`.

I'd also suggest adding a GitHub action to run the tests automatically when a pull request is opened.