### PR TITLE
Fix #41 - Add auto_detection option to control hljs' language detection feature

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -21,3 +21,10 @@ let converter = new showdown.Converter({
 })
 ```
 
+If you want to disable language [auto detection](https://highlightjs.org/usage/) feature of hljs, change `auto_detection` flag as `false`. With this option turned off, `showdown-highlight` will not process any codeblocks with no language specified.
+
+```js
+let converter = new showdown.Converter({
+    extensions: [showdownHighlight({ auto_detection: false })]
+})
+```

--- a/example/index.js
+++ b/example/index.js
@@ -11,7 +11,7 @@ let converter = new showdown.Converter({
         // Whether to add the classes to the <pre> tag, default is false
         pre: true
         // Whether to use hljs' auto language detection, default is true
-    ,   auto_detect: true
+    ,   auto_detection: true
     })]
 });
 

--- a/example/index.js
+++ b/example/index.js
@@ -8,8 +8,10 @@ const showdown = require('showdown')
 let converter = new showdown.Converter({
     // That's it
     extensions: [showdownHighlight({
-        // Whether to add the classes to the <pre> tag
+        // Whether to add the classes to the <pre> tag, default is false
         pre: true
+        // Whether to use hljs' auto language detection, default is true
+    ,   auto_detect: true
     })]
 });
 

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,4 +1,9 @@
 import type { ShowdownExtension } from "showdown";
 
-declare function showdownHighlight({ pre: Boolean, auto_detection: Boolean }): ShowdownExtension[];
+declare type ShowdownHighlightOptions = {
+  pre: boolean
+  auto_detection: boolean
+}
+
+declare function showdownHighlight(options?: Partial<ShowdownHighlightOptions>): ShowdownExtension[];
 export = showdownHighlight;

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,4 +1,4 @@
 import type { ShowdownExtension } from "showdown";
 
-declare function showdownHighlight({ pre: Boolean }): ShowdownExtension[];
+declare function showdownHighlight({ pre: Boolean, auto_detection: Boolean }): ShowdownExtension[];
 export = showdownHighlight;

--- a/lib/index.js
+++ b/lib/index.js
@@ -28,7 +28,7 @@ const decodeHtml = require("html-encoder-decoder").decode
  * @name showdownHighlight
  * @function
  */
-module.exports = function showdownHighlight({ pre = false } = {}) {
+module.exports = function showdownHighlight({ pre = false, auto_detection = true } = {}) {
     const filter = (text, converter, options) => {
         const params = {
             left: "<pre><code\\b[^>]*>"
@@ -40,6 +40,10 @@ module.exports = function showdownHighlight({ pre = false } = {}) {
             match = decodeHtml(match)
 
             const lang = (left.match(/class=\"([^ \"]+)/) || [])[1]
+
+            if (!lang && !auto_detection) {
+                return wholeMatch
+            }
 
             if (left.includes(classAttr)) {
                 const attrIndex = left.indexOf(classAttr) + classAttr.length

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "Cristiano Ribeiro <expedit@gmail.com> (https://github.com/expedit85)",
     "obedm503 (https://obedm503.github.io)",
     "Ariel Shaqed (Scolnicov) (https://github.com/arielshaqed)",
-    "Bruno de Araújo Alves (devbaraus) (https://github.com/devbaraus)"
+    "Bruno de Araújo Alves (devbaraus) (https://github.com/devbaraus)",
+    "Sekyu Kwon <xahhaepica@gmail.com> (https://github.com/Phryxia)"
   ]
 }

--- a/test/index.js
+++ b/test/index.js
@@ -54,7 +54,7 @@ sayHello("Hello World", "Johnny");
         })]
     })
 
-    t.should("process code block with language, when auto_detect disabled", () => {
+    t.should("process code block with language, when auto_detection disabled", () => {
         t.expect(converter_auto_disabled
             .makeHtml(CODEBLOCK_WITH_LANGUAGE)
             .includes('class="hljs js language-js"'))
@@ -65,7 +65,7 @@ sayHello("Hello World", "Johnny");
             .toEqual(true);
     })
 
-    t.should("not process code block with no language, when auto_detect disabled", () => {
+    t.should("not process code block with no language, when auto_detection disabled", () => {
         t.expect(converter_auto_disabled
             .makeHtml(CODEBLOCK_WITHOUT_LANGUAGE)
             .includes('hljs'))

--- a/test/index.js
+++ b/test/index.js
@@ -6,21 +6,30 @@ const tester = require("tester")
     ;
 
 tester.describe("showdown-highlight", t => {
-    // After requiring the module, use it as extension
-    let converter = new showdown.Converter({
-        extensions: [showdownHighlight]
-    });
-
-    t.should("A Showdown extension for highlight the code blocks.", () => {
-        // Now you can Highlight code blocks
-        let html = converter.makeHtml(`
+    const CODEBLOCK_WITH_LANGUAGE = `
 \`\`\`js
 function sayHello (msg, who) {
     return \`\${who} says: msg\`;
 }
 sayHello("Hello World", "Johnny");
+
+\`\`\``
+    const CODEBLOCK_WITHOUT_LANGUAGE = `
 \`\`\`
-        `);
+function sayHello (msg, who) {
+    return \`\${who} says: msg\`;
+}
+sayHello("Hello World", "Johnny");
+\`\`\``
+
+    // After requiring the module, use it as extension
+    const converter = new showdown.Converter({
+        extensions: [showdownHighlight]
+    });
+
+    t.should("A Showdown extension for highlight the code blocks.", () => {
+        // Now you can Highlight code blocks
+        let html = converter.makeHtml(CODEBLOCK_WITH_LANGUAGE);
 
         t.expect(html.includes('class="hljs js language-js"')).toEqual(true);
         t.expect(html.includes("hljs-string")).toEqual(true);
@@ -28,15 +37,42 @@ sayHello("Hello World", "Johnny");
 
     t.should("work without code block language", () => {
         // Now you can Highlight code blocks
-        let html = converter.makeHtml(`
-\`\`\`
-function sayHello (msg, who) {
-  return \`\${who} says: msg\`;
-}
-sayHello("Hello World", "Johnny");
-\`\`\`
-        `);
+        let html = converter.makeHtml(CODEBLOCK_WITHOUT_LANGUAGE);
 
         t.expect(html.includes('class="hljs"')).toEqual(true);
     });
+
+    const converter_auto_disabled = new showdown.Converter({
+        extensions: [showdownHighlight({
+            auto_detection: false
+        })]
+    })
+    const converter_auto_disabled_with_pre = new showdown.Converter({
+        extensions: [showdownHighlight({
+                auto_detection: false
+            ,   pre: true
+        })]
+    })
+
+    t.should("process code block with language, when auto_detect disabled", () => {
+        t.expect(converter_auto_disabled
+            .makeHtml(CODEBLOCK_WITH_LANGUAGE)
+            .includes('class="hljs js language-js"'))
+            .toEqual(true);
+        t.expect(converter_auto_disabled_with_pre
+            .makeHtml(CODEBLOCK_WITH_LANGUAGE)
+            .includes('class="hljs js language-js"'))
+            .toEqual(true);
+    })
+
+    t.should("not process code block with no language, when auto_detect disabled", () => {
+        t.expect(converter_auto_disabled
+            .makeHtml(CODEBLOCK_WITHOUT_LANGUAGE)
+            .includes('hljs'))
+            .toEqual(false)
+        t.expect(converter_auto_disabled_with_pre
+            .makeHtml(CODEBLOCK_WITHOUT_LANGUAGE)
+            .includes('hljs'))
+            .toEqual(false)
+    })
 });


### PR DESCRIPTION
# Related Issue

#41

# Changes

- Add `auto_detection` option to enable/bypass hljs' language detection
   - When `auto_detection` is `true`, it works equivalent to previous version
   - When `auto_detection` is `false`, originally matched HTML fragment will be returned without any changes
      - This means there is no `class="hljs"` at all
   - The default behavior is `true` to preserve compatibility
- Add more test cases for added option
- Fix TypeScript declaration for option as `Partial`
- Extract repetitive test input as `const`
- Update `example` and `DOCUMENTATION`.

For more details, please checkout my self review.

# Note

- I tried to follow all of your code convention, but some of them are ambiguous. Feedback is wanted. @IonicaBizau
- I couldn't find any `blah` related proper boilerplates in this repository. But `REAMDE` says no modification is allowed as it is generated from `blah`. If I just run `blah --readme` and this will erase almost everything. We should fix this, or just add manually to `README.`