### PR TITLE
Ensure to strip any code block annotation after language name

### DIFF
--- a/.github/workflows/showdown-highlight-tests.yml
+++ b/.github/workflows/showdown-highlight-tests.yml
@@ -1,0 +1,21 @@
+name: showdown-highlight-tests
+
+on: [push, pull_request]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [18.x, 20.x, 22.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm install
+      - run: npm test

--- a/lib/index.js
+++ b/lib/index.js
@@ -51,10 +51,15 @@ module.exports = function showdownHighlight({ pre = false, auto_detection = true
         const replacement = (wholeMatch, match, left, right) => {
             match = decodeHtml(match)
 
-            const lang = (left.match(/class=\"([^ \"]+)/) || [])[1]
+            let lang = (left.match(/class=\"([^ \"]+)/) || [])[1]
 
             if (!lang && !auto_detection) {
                 return wholeMatch
+            } else if (lang && lang.indexOf(',') > 0) {
+                // ensure to strip any code block annotation after language
+                const langNoAnnotation = lang.slice(0, lang.indexOf(','));
+                left = left.replace(new RegExp(lang, 'g'), langNoAnnotation);
+                lang = langNoAnnotation;
             }
 
             if (left.includes(classAttr)) {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "obedm503 (https://obedm503.github.io)",
     "Ariel Shaqed (Scolnicov) (https://github.com/arielshaqed)",
     "Bruno de Araújo Alves (devbaraus) (https://github.com/devbaraus)",
-    "Sekyu Kwon <xahhaepica@gmail.com> (https://github.com/Phryxia)"
+    "Sekyu Kwon <xahhaepica@gmail.com> (https://github.com/Phryxia)",
+    "Antoine Lambert <anlambert@softwareheritage.org> (https://github.com/anlambert)"
   ]
 }

--- a/test/index.js
+++ b/test/index.js
@@ -12,14 +12,21 @@ function sayHello (msg, who) {
     return \`\${who} says: msg\`;
 }
 sayHello("Hello World", "Johnny");
-
 \`\`\``
+
     const CODEBLOCK_WITHOUT_LANGUAGE = `
 \`\`\`
 function sayHello (msg, who) {
     return \`\${who} says: msg\`;
 }
 sayHello("Hello World", "Johnny");
+\`\`\``
+
+    const CODEBLOCK_WITH_LANGUAGE_AND_ANNOTATION = `
+\`\`\`rust,no_run
+fn do_amazing_thing() -> i32 {
+   unimplemented!()
+}
 \`\`\``
 
     // After requiring the module, use it as extension
@@ -40,6 +47,12 @@ sayHello("Hello World", "Johnny");
         let html = converter.makeHtml(CODEBLOCK_WITHOUT_LANGUAGE);
 
         t.expect(html.includes('class="hljs"')).toEqual(true);
+    });
+
+    t.should("work with code block language and annotation", () => {
+        let html = converter.makeHtml(CODEBLOCK_WITH_LANGUAGE_AND_ANNOTATION);
+        t.expect(html.includes('class="hljs rust language-rust"')).toEqual(true);
+        t.expect(html.includes("hljs-type")).toEqual(true);
     });
 
     const converter_auto_disabled = new showdown.Converter({


### PR DESCRIPTION
Some markdown files can contain extra code block annotations after the language name, separated by commas.

Such extra annotations break code highlighting after processing by `showdown-highlight` as the language name ends up invalid and cannot be found by `highlight.js`.

For instance, the README of https://github.com/budziq/rust-skeptic repository contains such code block annotations and we can see they are properly rendered by GitHub. However, when browsing the [archived version](https://archive.softwareheritage.org/browse/origin/directory/?origin_url=https://github.com/budziq/rust-skeptic) of that repository in Software Heritage, whose website uses `showdownjs` and `showdown-highlight`, we can see the renderings of such code blocks are broken.

So ensure to strip these extra annotations to fix HTML rendering.

I also added a GitHub Actions job to execute the tests of `showdown-highlight`.
